### PR TITLE
Open file in new window when download attribute isn't supported

### DIFF
--- a/file-download.js
+++ b/file-download.js
@@ -10,6 +10,7 @@ module.exports = function(data, filename) {
         var tempLink = document.createElement('a');
         tempLink.href = csvURL;
         tempLink.setAttribute('download', filename);
+        tempLink.setAttribute('target', '_blank');
         tempLink.click();
     }
 }


### PR DESCRIPTION
Since the `download` attribute isn't supported in the current versions Safari or IE, adding a `target` attribute to the link makes the file at least open in a new window so that the user doesn't lose their current page/state.