### PR TITLE
Remove unused React dependency

### DIFF
--- a/file-download.js
+++ b/file-download.js
@@ -1,5 +1,3 @@
-var React = require('react');
-
 module.exports = function(data, filename, mime) {
     var blob = new Blob([data], {type: mime || 'application/octet-stream'});
     if (typeof window.navigator.msSaveBlob !== 'undefined') {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "devDependencies": {
-    "react": "^0.14.7"
-  },
-  "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0"
-  },
   "repository": {
     "type": "git",
     "url": "git@github.com:kennethjiang/react-file-download.git"


### PR DESCRIPTION
None of the code actually depends on React, so I guess it's best to remove it.

You could also rename the project to "file download" :-)