### PR TITLE
Issue #16: Fixing tempLink.style attribute

### DIFF
--- a/file-download.js
+++ b/file-download.js
@@ -10,7 +10,7 @@ module.exports = function(data, filename, mime) {
     else {
         var blobURL = window.URL.createObjectURL(blob);
         var tempLink = document.createElement('a');
-        tempLink.style = "display: none";
+        tempLink.style.display = 'none';
         tempLink.href = blobURL;
         tempLink.setAttribute('download', filename);
         tempLink.setAttribute('target', '_blank');


### PR DESCRIPTION
Commit 4524750 is giving me the following message in Safari, "TypeError: Attempted to assign to readonly property."

I believe setting the "display: none" property-value pair of CSSStyleDeclaration should be done according to this commit.