### PR TITLE
Issue #5: Remove target="_blank" attribute.

### DIFF
--- a/file-download.js
+++ b/file-download.js
@@ -13,7 +13,6 @@ module.exports = function(data, filename, mime) {
         tempLink.style = "display: none";
         tempLink.href = blobURL;
         tempLink.setAttribute('download', filename);
-        tempLink.setAttribute('target', '_blank');
         document.body.appendChild(tempLink);
         tempLink.click();
         document.body.removeChild(tempLink);


### PR DESCRIPTION
From Safari 5+ (and maybe earlier) the default browser configuration has Safari > Preferences > Block pop-up windows enabled. This disables anchors with target="_blank" from opening in a new tab.

Safari 10.1+ supports the "download" attribute (see http://caniuse.com/#feat=download). When target="_blank" was in place, due to the pop-up blocking setting, I think Safari ignored the entire anchor... because the download didn't work at all. With target="_blank" removed, the browser uses the default target="_self" behaviour and Safari 10.1 downloads work as expected.