### PR TITLE
Add workaround to allow users on desktop safari to download files eve…

### DIFF
--- a/file-download.js
+++ b/file-download.js
@@ -12,8 +12,16 @@ module.exports = function(data, filename, mime) {
         var tempLink = document.createElement('a');
         tempLink.style.display = 'none';
         tempLink.href = blobURL;
-        tempLink.setAttribute('download', filename);
-        tempLink.setAttribute('target', '_blank');
+        tempLink.setAttribute('download', filename); 
+        
+        // Safari thinks _blank anchor are pop ups. We only want to set _blank
+        // target if the browser does not support the HTML5 download attribute.
+        // This allows you to download files in desktop safari if pop up blocking 
+        // is enabled.
+        if (typeof tempLink.download === 'undefined') {
+            tempLink.setAttribute('target', '_blank');
+        }
+        
         document.body.appendChild(tempLink);
         tempLink.click();
         document.body.removeChild(tempLink);


### PR DESCRIPTION
Stumbled upon an issue where downloads were not working in Safari (Desktop & Mobile) and stumbled upon this pull request: https://github.com/kennethjiang/react-file-download/pull/21

This modifies @rmiller-fc original work to only set the target to be blank if the browser does not support the HTML5 download attribute.

This has fixed the issue in the latest desktop Safari version whereby pop ups being blocked were preventing downloads to work. This is due to Safari believing that anchor tags with a target of _blank are pop ups.

This does not fix the issue on mobile Safari as it does not support the HTML5 download attribute and probably will not do so as Safari on mobile does not allow you to download files directly to the device.

This should not affect any of the other browsers that do support the HTML5 download attribute in any way.